### PR TITLE
Accept 'ttype' parameter in BlackHole problem

### DIFF
--- a/inverse_problems/blackhole.py
+++ b/inverse_problems/blackhole.py
@@ -19,7 +19,7 @@ class BlackHoleImaging(BaseOperator):
         This class utilize a reference observation for observation setup (e.g. telescope u,v map)
     """
 
-    def __init__(self, root='dataset/blackhole', observation_time_ratio=1.0, noise_type='vis_thermal', imsize=64, w1=0,
+    def __init__(self, root='dataset/blackhole', observation_time_ratio=1.0, noise_type='vis_thermal', ttype='nfft', imsize=64, w1=0,
                  w2=1, w3=1, w4=0.5, sigma_noise=0.0, unnorm_shift=1.0, unnorm_scale=0.5, device='cuda'):
         super().__init__(sigma_noise, unnorm_shift, unnorm_scale, device)
         # load observations
@@ -30,6 +30,7 @@ class BlackHoleImaging(BaseOperator):
         self.ref_multiplier = multiplier
         self.observation_time_ratio = observation_time_ratio
         self.noise_type = noise_type
+        self.ttype = ttype  # 'fast' | 'nfft' | 'direct'
 
         # Get index  matrix for closure phases and closure amplitudes
         self.get_index_matrix(obs)
@@ -296,7 +297,7 @@ class BlackHoleImaging(BaseOperator):
             eh_image.ivec = eh_image.ivec * multiplier
 
             # observe the image
-            obs = eh_image.observe_same_nonoise(ref_obs, verbose=False)
+            obs = eh_image.observe_same_nonoise(ref_obs, ttype=self.ttype, verbose=False)
 
             # visibilities amplitude
             adf = ehdf.make_amp(obs, debias=False)
@@ -401,7 +402,7 @@ class BlackHoleImaging(BaseOperator):
             eh_image.ivec = eh_image.ivec * multiplier
 
             # observe the image
-            obs = eh_image.observe_same(ref_obs, phasecal=False, ampcal=False, verbose=False)
+            obs = eh_image.observe_same(ref_obs, phasecal=False, ampcal=False, ttype=self.ttype, verbose=False)
             # eht_obs.append(obs)
 
             # visibilities amplitude


### PR DESCRIPTION
`ehtim` by default uses `ttype='nfft'` to perform Fourier transforms, but `ttype='nfft'` requires `pyNFFT`, which is outdated and requires the `NFFT` C package.  By adding a `ttype` parameter to the `BlackHoleImaging` forward operator, users can pass in a different `ttype` value (i.e., `"fast"`, `"nfft"`, or `"direct"`), including one that doesn't require `pyNFFT`.